### PR TITLE
[Fix] Fix torchprofiler usage after torch 2.4+

### DIFF
--- a/src/cuda_mock/cuda_mock_impl.py
+++ b/src/cuda_mock/cuda_mock_impl.py
@@ -169,7 +169,10 @@ class __GpuRuntimeProfiler:
 
         data = []
         for it in time_list:
-            data.append((it.key, it.cuda_time_total_str))
+            if hasattr(it, "cuda_time_total_str"):
+                data.append((it.key, it.cuda_time_total_str))
+            else:
+                data.append((it.key, it.device_time_total_str)) #rename cuda_time_total_str to device_time_total_str in 2.4 or 2.3
             #print(it)
             #print(it.key)
             #print(it.self_cuda_time_total_str)


### PR DESCRIPTION
python 2.3 或者是 2.4 将cuda_time_total_str改为了device_time_total_str